### PR TITLE
Add Python 3.7 and 3.8 support and drop Python 3.5 and 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 python:
-  - "3.5"
-  - "3.6"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8"
+  - "3.9-dev"
 matrix:
   allow_failures:
-    - python: "3.7-dev"
+    - python: "3.9-dev"
 before_install: true
 install:
   - pip install -U pip

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/reupen/aiogithub.svg?branch=master)](https://travis-ci.org/reupen/aiogithub) [![Requirements Status](https://requires.io/github/reupen/aiogithub/requirements.svg?branch=master)](https://requires.io/github/reupen/aiogithub/requirements/?branch=master) [![Documentation Status](https://readthedocs.org/projects/aiogithub/badge/?version=latest)](http://aiogithub.readthedocs.io/en/latest/?badge=latest)
 
-asyncio- and aiohttp-based Python 3.5 GitHub API client.
+asyncio- and aiohttp-based Python 3.7 and newer GitHub API client.
 
 Note: This library is a work in progress. So far, select read operations have been implemented.
 
@@ -44,6 +44,5 @@ asyncio.get_event_loop().run_until_complete(main())
 Currently, only development versions are available. You can install the current development version by running:
 
 ```
-pip3.5 install -U setuptools
-pip3.5 install git+https://github.com/reupen/aiogithub.git#egg=aiogithub
+pip install git+https://github.com/reupen/aiogithub.git#egg=aiogithub
 ```

--- a/aiogithub/helpers/typing.py
+++ b/aiogithub/helpers/typing.py
@@ -1,12 +1,12 @@
-from typing import GenericMeta, List
+from typing import _GenericAlias
 
 
 def is_generic_type_hint(T):
-    return isinstance(T, GenericMeta)
+    return isinstance(T, _GenericAlias)
 
 
 def is_list_type_hint(T):
-    return is_generic_type_hint(T) and T.__origin__ == List
+    return is_generic_type_hint(T) and T.__origin__ is list
 
 
 def get_list_element_hint(T):

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 Prerequisites
 -------------
 
-aiogithub requires Python 3.5 or newer.
+aiogithub requires Python 3.7 or newer.
 
 Installation of development versions
 ------------------------------------
@@ -13,5 +13,4 @@ Currently, only development versions are available. You can install the current 
 
 .. code-block:: batch
 
-    pip3.5 install -U setuptools
-    pip3.5 install git+https://github.com/reupen/aiogithub.git#egg=aiogithub
+    pip install git+https://github.com/reupen/aiogithub.git#egg=aiogithub

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,12 @@ if is_sphinx:
     setup_requires += (
         'sphinx-rtd-theme',
         'sphinxcontrib-asyncio',
-        'Sphinx~=1.4.6'
+        'Sphinx~=1.4'
     )
 
 if is_flake8:
     setup_requires += (
-        'flake8~=3.3.0',
+        'flake8~=3.7',
     )
 
 setup(
@@ -37,7 +37,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     install_requires=[
         'aiohttp~=3.0',
-        'async-timeout',
+        'async-timeout~=3.0',
         'LinkHeader~=0.4',
         'uritemplate~=3.0',
         'python-dateutil~=2.5'
@@ -47,7 +47,7 @@ setup(
 
     python_requires='~=3.5',
     setup_requires=setup_requires,
-    tests_require=['pytest-asyncio~=0.5.0'],
+    tests_require=['pytest-asyncio~=0.10.0'],
 
     author="Reupen Shah",
     description="asyncio-based GitHub API client",
@@ -56,8 +56,8 @@ setup(
     url="https://github.com/reupen/aiogithub",
 
     classifiers=[
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Development Status :: 2 - Pre-Alpha'
     ]
 )


### PR DESCRIPTION
This is a fairly quick attempt at supporting Python 3.7 and 3.8.

Support for Python 3.5 and 3.6 is dropped as a result.